### PR TITLE
fix(deploy): fix broken Vercel web build (missing node) and run migrations safely

### DIFF
--- a/apps/web/lib/db/migrate.ts
+++ b/apps/web/lib/db/migrate.ts
@@ -4,7 +4,8 @@ import { SQL } from "bun";
 
 async function runMigrations() {
   if (!process.env.DATABASE_URL) {
-    throw new Error("DATABASE_URL environment variable is required");
+    console.warn("⚠️  DATABASE_URL not set — skipping migrations.");
+    return;
   }
 
   console.log("🚀 Starting database migrations...");

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "bunVersion": "1.x",
-  "buildCommand": "bun --bun run build"
+  "buildCommand": "bun --bun run build:only"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "bunVersion": "1.x"
+  "bunVersion": "1.x",
+  "buildCommand": "bun --bun run build"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "bunVersion": "1.x",
-  "buildCommand": "bun --bun run build:only"
+  "buildCommand": "bun --bun run build"
 }


### PR DESCRIPTION
## Why the build was broken

The Vercel **web** deployment was failing on every deploy — independent of any dependency change (even a formatter-only Renovate PR failed identically), which is why committing the lockfile never helped. The lockfile governs dependency *resolution*; the breakage was at a different layer.

Root cause, from the Vercel log:

```
Running "turbo run build"
env: 'node': No such file or directory
Error: Command "turbo run build" exited with 127
```

`node_modules/.bin/turbo` starts with `#!/usr/bin/env node`, but the build image is Bun-only (`bunVersion: 1.x`) — there is no `node` on `PATH`, so the deploy died at `127` before the build even started. Every other turbo invocation in the repo goes through `bun --bun run`, where `--bun` makes Bun execute node-shebang scripts itself. The Vercel build command (auto-detected `turbo run build`) was the one place that didn't.

Reproduced locally in a no-node environment:

| Command | Result |
| --- | --- |
| `turbo run …` (old behavior) | `env: 'node': No such file or directory` |
| `bun --bun run …` (this fix) | runs clean, no node needed |

## What changed

- **`vercel.json`** — set `"buildCommand": "bun --bun run build"` so the build runs through Bun and the `turbo` node-shebang resolves to Bun. (Leave the Vercel dashboard "Override" for Build Command **off** — `vercel.json` takes precedence on its own.)
- **`apps/web/lib/db/migrate.ts`** — the `build` script runs `db:migrate && next build`. Migrations should still run on deploy, but the script previously hard-threw when `DATABASE_URL` was absent, which would break databaseless builds (preview deploys, local `next build`). It now skips with a warning when `DATABASE_URL` is not set. Production, which has `DATABASE_URL` configured, still applies migrations during deploy, and a genuine migration error still fails the build via `process.exit(1)`.

## Verification

- Reproduced the exact `env: 'node'` failure locally and confirmed `bun --bun run build` clears it.
- `bun --bun run build` passes end to end: migrations skip cleanly without a DB, then `next build` completes (3/3 turbo tasks successful).

## Note (out of scope)

The red GitHub Actions CI on the Renovate PRs (`react-day-picker` v10, `fumadocs`, `react` monorepo) is a **separate** breakage — real API changes in shadcn-vendored components, not this deploy issue. Happy to tackle those and/or tune `renovate.json` in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ojYEGqoPBHf2AW3bBs2hS

---
_Generated by [Claude Code](https://claude.ai/code/session_013ojYEGqoPBHf2AW3bBs2hS)_